### PR TITLE
Use .pkg installer, set a minimum macOS version and add uninstall and gpg stanzas

### DIFF
--- a/Casks/background-music.rb
+++ b/Casks/background-music.rb
@@ -6,6 +6,8 @@ cask 'background-music' do
   name 'Background Music'
   homepage 'https://github.com/kyleneideck/BackgroundMusic'
 
+  depends_on macos: '>= 10.9'
+
   pkg "BackgroundMusic-#{version}.pkg"
 
   uninstall script:    {

--- a/Casks/background-music.rb
+++ b/Casks/background-music.rb
@@ -5,6 +5,7 @@ cask 'background-music' do
   url "https://github.com/kyleneideck/BackgroundMusic/releases/download/v#{version}/BackgroundMusic-#{version}.pkg"
   name 'Background Music'
   homepage 'https://github.com/kyleneideck/BackgroundMusic'
+  gpg "#{url}.asc", key_id: '0595df814e41a6f69334c5e2caa8d9b8e39ec18c'
 
   depends_on macos: '>= 10.9'
 

--- a/Casks/background-music.rb
+++ b/Casks/background-music.rb
@@ -1,11 +1,22 @@
 cask 'background-music' do
-  version 'untagged-221ecabb2d939df5ed86'
-  sha256 'deae401360b3471fb1e08c1cca8eb7889906e5d974d0a484d3188bae6507c03d'
+  version '0.1.1'
+  sha256 '7ce875bb00fdeb2b5b363aa92367b3fa096d18cb02a02c461d5df66307ab1088'
 
-  # github.com/sscotth/backgroundmusic was verified as **not** official when first introduced to the cask
-  url "https://github.com/sscotth/backgroundmusic/releases/download/#{version}/BackgroundMusic.app.zip"
+  url "https://github.com/kyleneideck/BackgroundMusic/releases/download/v#{version}/BackgroundMusic-#{version}.pkg"
   name 'Background Music'
   homepage 'https://github.com/kyleneideck/BackgroundMusic'
 
-  app 'Background Music.app'
+  pkg "BackgroundMusic-#{version}.pkg"
+
+  uninstall script:    {
+                         executable: "#{appdir}/Background Music.app/Contents/Resources/_uninstall-non-interactive.sh",
+                         sudo:       false,
+                       },
+            pkgutil:   'com.bearisdriving.BGM',
+            quit:      [
+                         'com.bearisdriving.BGM.App',
+                       ],
+            launchctl: [
+                         'com.bearisdriving.BGM.XPCHelper',
+                       ]
 end


### PR DESCRIPTION
I've written a .pkg installer for Background Music and merged your changes to the Travis build script into my fork. This PR points the formula at the latest .pkg release from Travis, [0.1.1](https://github.com/kyleneideck/BackgroundMusic/releases/tag/v0.1.1).

I don't think Homebrew Cask actually verifies the GPG signature yet, so I'm not sure if there's any way to test the `gpg` stanza I added.

I split the Background Music uninstaller script into an interactive and non-interactive part so the cask can be uninstalled normally. The `uninstall` stanza calls the non-interactive part directly with its `script` key. (The other keys are redundant.)

You still have to manually change your default audio output device after uninstalling. `brew cask uninstall background-music` prints a message about it, but it could probably be made more obvious. I'm not sure how Homebrew Cask normally handles apps that need manual intervention.

It would probably be possible to toggle the default device automatically at the end of the uninstaller script, but it would be a bit tricky and error prone. I think we'd have to create an aggregate device that contains the user's real default device and toggle between the two.